### PR TITLE
Omit the local version part in VCS options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "pelican/plugins/pelican_redirect/_version.py"
 
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatch-vcs", "hatchling"]


### PR DESCRIPTION
Proposed as a solution in https://github.com/ofek/hatch-vcs/issues/43